### PR TITLE
control: min/max as float64

### DIFF
--- a/control.go
+++ b/control.go
@@ -15,8 +15,8 @@ type ControlArgs interface {
 	SetType(string) ControlArgs
 	SetUnits(string) ControlArgs
 	SetReadonly(bool) ControlArgs
-	SetMax(int) ControlArgs
-	SetMin(int) ControlArgs
+	SetMax(float64) ControlArgs
+	SetMin(float64) ControlArgs
 	SetPrecision(float64) ControlArgs
 	SetError(ControlError) ControlArgs
 	SetOrder(int) ControlArgs
@@ -36,8 +36,8 @@ type ControlArgs interface {
 	GetType() *string
 	GetUnits() *string
 	GetReadonly() *bool
-	GetMax() *int
-	GetMin() *int
+	GetMax() *float64
+	GetMin() *float64
 	GetPrecision() *float64
 	GetError() ControlError
 	GetOrder() *int
@@ -79,8 +79,8 @@ type Control interface {
 	GetType() string                 // Gets control type string (/meta/type) (TODO: special type for this)
 	GetUnits() string                // Gets control value units (/meta/units)
 	GetReadonly() bool               // Checks whether control is read only
-	GetMax() int                     // Gets max value for 'range' type (FIXME: rework this?)
-	GetMin() int                     // Gets min value for 'range' type
+	GetMax() float64                 // Gets max value for 'range'/'value' type (FIXME: rework this?)
+	GetMin() float64                 // Gets min value for 'range'/'value' type
 	GetPrecision() float64           // Gets precision for 'value' type
 	GetError() ControlError          // Gets control error (/meta/error)
 	GetOrder() int                   // Gets control order (or -1 for auto) (/meta/order)
@@ -95,8 +95,8 @@ type Control interface {
 	SetType(t string) FuncError
 	SetUnits(units string) FuncError
 	SetReadonly(r bool) FuncError
-	SetMax(max int) FuncError
-	SetMin(min int) FuncError
+	SetMax(max float64) FuncError
+	SetMin(min float64) FuncError
 	SetPrecision(prec float64) FuncError
 	SetError(e ControlError) FuncError
 	SetOrder(ord int) FuncError


### PR DESCRIPTION
`type: value` по конвенции это float, поэтому и min/max нужен в виде float64. В libwbmqtt min/max тоже имеют тип double.