### PR TITLE
testutils: add Touch to DataFileFixture

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,7 +1,7 @@
 package wbgong
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"log/syslog"
 	"os"
@@ -27,7 +27,7 @@ func init() {
 	Error = log.New(os.Stderr, "ERROR: ", log.LstdFlags)
 	Warn = log.New(os.Stderr, "WARNING: ", log.LstdFlags)
 	Info = log.New(os.Stderr, "INFO: ", log.LstdFlags)
-	Debug = log.New(ioutil.Discard, "", 0)
+	Debug = log.New(io.Discard, "", 0)
 }
 
 func MakeSyslogger(priority syslog.Priority, prefix string) *log.Logger {
@@ -66,7 +66,7 @@ func updateDebugLogger() {
 	case keepDebug:
 		return
 	case !DebuggingEnabled():
-		Debug = log.New(ioutil.Discard, "", 0)
+		Debug = log.New(io.Discard, "", 0)
 	case useSyslog:
 		Debug = MakeSyslogger(syslog.LOG_DAEMON|syslog.LOG_DEBUG, "DEBUG: ")
 	default:

--- a/testutils/datafilefixture.go
+++ b/testutils/datafilefixture.go
@@ -1,12 +1,12 @@
 package testutils
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 var oldRmDataDir func()
@@ -63,7 +63,7 @@ func (f *DataFileFixture) ensureTargetDirs(targetName string) (targetPath string
 }
 
 func (f *DataFileFixture) readSourceDataFile(sourceName string) []byte {
-	data, err := ioutil.ReadFile(filepath.Join(f.wd, sourceName))
+	data, err := os.ReadFile(filepath.Join(f.wd, sourceName))
 	f.Ckf("ReadFile()", err)
 	return data
 }
@@ -75,14 +75,14 @@ func (f *DataFileFixture) ReadSourceDataFile(sourceName string) string {
 func (f *DataFileFixture) CopyModifiedDataFileToTempDir(sourceName, targetName string, edit func(string) string) (targetPath string) {
 	data := string(f.readSourceDataFile(sourceName))
 	targetPath = f.ensureTargetDirs(targetName)
-	f.Ckf("WriteFile", ioutil.WriteFile(targetPath, []byte(edit(data)), 0777))
+	f.Ckf("WriteFile", os.WriteFile(targetPath, []byte(edit(data)), 0777))
 	return
 }
 
 func (f *DataFileFixture) CopyDataFileToTempDir(sourceName, targetName string) (targetPath string) {
 	data := f.readSourceDataFile(sourceName)
 	targetPath = f.ensureTargetDirs(targetName)
-	f.Ckf("WriteFile", ioutil.WriteFile(targetPath, data, 0777))
+	f.Ckf("WriteFile", os.WriteFile(targetPath, data, 0777))
 	return
 }
 
@@ -99,10 +99,15 @@ func (f *DataFileFixture) CopyDataFilesToTempDir(names ...string) {
 
 func (f *DataFileFixture) WriteDataFile(filename, content string) string {
 	targetPath := f.ensureTargetDirs(filename)
-	f.Ckf("WriteFile()", ioutil.WriteFile(targetPath, []byte(content), 0777))
+	f.Ckf("WriteFile()", os.WriteFile(targetPath, []byte(content), 0777))
 	return targetPath
 }
 
 func (f *DataFileFixture) RmFile(filename string) {
 	f.Ckf("Remove()", os.Remove(f.DataFilePath(filename)))
+}
+
+func (f *DataFileFixture) Touch(filename string, time time.Time) {
+	targetPath := f.ensureTargetDirs(filename)
+	f.Ckf("Chtimes()", os.Chtimes(targetPath, time, time))
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -366,7 +365,7 @@ func SetupTempDir(t *testing.T) (string, func()) {
 		return "", nil // never reached
 	}
 
-	dir, err := ioutil.TempDir(os.TempDir(), "wbgongtest")
+	dir, err := os.MkdirTemp("", "wbgongtest")
 	if err != nil {
 		require.FailNow(t, "couldn't create temporary directory")
 		return "", nil // never reached


### PR DESCRIPTION
* testutils: add `Touch` method to `DataFileFixture`
* replace deprecated ioutil functions (see https://pkg.go.dev/io/ioutil)